### PR TITLE
Improve linktype detection textfield

### DIFF
--- a/src/extractlastlinkfromlynx.c
+++ b/src/extractlastlinkfromlynx.c
@@ -38,7 +38,7 @@ int main(int argc, char * argv[])
           && ( fgetc(stdin) == 'm' ) ) {
             i=0;
             while ( (ichar=fgetc(stdin)) != EOF && ichar != '\033' 
-                    && ( jchar!='4' || ichar == ' ' || ichar == '(' || ( ichar >= 'A' && ichar <= 'z' ) ) )
+                    && ( jchar!='4' || ichar == ' ' || ichar == '(' || ( ichar >= 'A' && ichar <= 'z' ) || ichar == '%' || ichar == '"' ) )
                 if ( i < SIZEMAX-1 && ( jchar!='4' || ichar != '(' ) )
                     current[i++]=ichar;
 

--- a/src/init_lynxbot
+++ b/src/init_lynxbot
@@ -464,7 +464,7 @@ function LB_stop_int_trap {
 	fi
 	# to avoid double stop calls, and try to close fd 8 only if it is opened
 	if [ -e /proc/$$/fd/8 ]; then
-		if LB_get_current_linktype | grep -i "\(textarea\|entry field\)" > /dev/null ; then
+		if LB_get_current_linktype | grep -i "\(textarea\|entry field\|Textfield\)" > /dev/null ; then
 			echo "key ^V" >&8
 		fi
 		echo "key ^D" >&8

--- a/src/init_lynxbot
+++ b/src/init_lynxbot
@@ -115,7 +115,7 @@ return 0"
 function LB_get_current_page {
 	CurrentPage="${1:-current_page}"
 	[ ! -f "$CurrentPage" ] || rm -f "$CurrentPage" || return 3
-	if LB_get_current_linktype | grep -i "\(textarea\|entry field\)" > /dev/null ; then
+	if LB_get_current_linktype | grep -i "\(textarea\|entry field\|Textfield\)" > /dev/null ; then
 		echo "key ^V" >&8
 	fi
 	echo "key p" >&8
@@ -137,7 +137,7 @@ return 0"
 function LB_get_current_source {
 	CurrentPage="${1:-current_source}"
 	[ ! -f "$CurrentPage" ] || rm -f "$CurrentPage" || return 3
-	if LB_get_current_linktype | grep -i "\(textarea\|entry field\)" > /dev/null ; then
+	if LB_get_current_linktype | grep -i "\(textarea\|entry field\|Textfield\)" > /dev/null ; then
 		echo "key ^V" >&8
 	fi
 	echo "key \\" >&8
@@ -216,7 +216,7 @@ Jump to the first link of the page.
 echo: nothing
 return 0"
 function LB_go_firstl {
-	if LB_get_current_linktype | grep -i "\(textarea\|entry field\)" > /dev/null ; then
+	if LB_get_current_linktype | grep -i "\(textarea\|entry field\|Textfield\)" > /dev/null ; then
 		echo "key ^V" >&8
 	fi
 	echo "key Home" >&8
@@ -230,7 +230,7 @@ Jump to the last link of the page.
 echo: nothing
 return 0"
 function LB_go_lastl {
-	if LB_get_current_linktype | grep -i "\(textarea\|entry field\)" > /dev/null ; then
+	if LB_get_current_linktype | grep -i "\(textarea\|entry field\|Textfield\)" > /dev/null ; then
 		echo "key ^V" >&8
 	fi
 	echo "key End" >&8
@@ -247,7 +247,7 @@ function LB_secure_go_to_url {
 	[ "$1" ] || return 9
 
 	[ ! -f "/tmp/current_error.$LynxBotPid" ] || rm -f "/tmp/current_error.$LynxBotPid" || return 3
-	if LB_get_current_linktype | grep -i "\(textarea\|entry field\)" > /dev/null ; then
+	if LB_get_current_linktype | grep -i "\(textarea\|entry field\|Textfield\)" > /dev/null ; then
 		echo "key ^V" >&8
 	fi
 	echo "key g" >&8
@@ -267,7 +267,7 @@ return 9 if no given url, else 0."
 function LB_go_to_url {
 	[ "$1" ] || return 9
 
-	if LB_get_current_linktype | grep -i "\(textarea\|entry field\)" > /dev/null ; then
+	if LB_get_current_linktype | grep -i "\(textarea\|entry field\|Textfield\)" > /dev/null ; then
 		echo "key ^V" >&8
 	fi
 	echo "key g" >&8
@@ -280,7 +280,7 @@ LB_Help_refresh_page="LB_refresh_page
 echo: nothing
 return 0."
 function LB_refresh_page {
-	if LB_get_current_linktype | grep -i "\(textarea\|entry field\)" > /dev/null ; then
+	if LB_get_current_linktype | grep -i "\(textarea\|entry field\|Textfield\)" > /dev/null ; then
 		echo "key ^V" >&8
 	fi
 	echo "key ^R" >&8
@@ -294,7 +294,7 @@ return 0"
 function LB_get_current_info {
 	CurrentPage="${1:-current_info}"
 	[ ! -f "$CurrentPage" ] || rm -f "$CurrentPage" || return 3
-	if LB_get_current_linktype | grep -i "\(textarea\|entry field\)" > /dev/null ; then
+	if LB_get_current_linktype | grep -i "\(textarea\|entry field\|Textfield\)" > /dev/null ; then
 		echo "key ^V" >&8
 	fi
 
@@ -322,7 +322,7 @@ return 0"
 function LB_get_cookies_info {
 	CurrentPage="${1:-cookies_info}"
 	[ ! -f "$CurrentPage" ] || rm -f "$CurrentPage" || return 3
-	if LB_get_current_linktype | grep -i "\(textarea\|entry field\)" > /dev/null ; then
+	if LB_get_current_linktype | grep -i "\(textarea\|entry field\|Textfield\)" > /dev/null ; then
 		echo "key ^V" >&8
 	fi
 
@@ -378,7 +378,7 @@ Argument 2...: passed to grep to search link type (mandatory)
 echo: the number of parsed links, followed by the founded link type (grep output).
 return 0 if the linktype is found, 9 if not.
 
-Note: Types use to be: 'Unknow', 'NORMAL LINK', 'Text entry field', 'Password entry field', 'Form submit button', 'Radio Button', 'Checkbox Field', 'Option list', 'Choice list' and Textarea."
+Note: Types use to be: 'Unknow', 'NORMAL LINK', 'Text entry field' or 'Textfield \"%s\"', 'Password entry field', 'Form submit button', 'Radio Button', 'Checkbox Field', 'Option list', 'Choice list' and Textarea."
 # type can be
 # 0 Unknow
 # 1 NORMAL LINK
@@ -419,7 +419,7 @@ Argument 1: String to write in a Text entry field.
 echo: nothing
 return 9 if current type is not ' entry field' or 'Textarea', 0 if OK."
 function LB_write_string {
-	LB_get_current_linktype | grep -i "\(textarea\|entry field\)" > /dev/null || return 9
+	LB_get_current_linktype | grep -i "\(textarea\|entry field\|Textfield\)" > /dev/null || return 9
 	"$LynxBotBin"/setstrforlynx "$1" >&8
 }
 export -f LB_write_string
@@ -429,7 +429,7 @@ Close the connected lynx and lynxbot.sh session.
 echo: nothing
 return 0."
 function LB_stop {
-	if LB_get_current_linktype | grep -i "\(textarea\|entry field\)" > /dev/null ; then
+	if LB_get_current_linktype | grep -i "\(textarea\|entry field\|Textfield\)" > /dev/null ; then
 		echo "key ^V" >&8
 	fi
 	echo "key ^D" >&8


### PR DESCRIPTION
Bonjour,

J'ai apporté deux corrections liées au type de lien [Textfield "%s"].
J'ai pu voir que le type de lien n'était pas détecté lorsque j'étais sur un champ de type "champ de texte". La valeur du précédent lien visité était retournée.
Je pense que cela doit être dû à une différence entre le moment ou Lynxbot a été développé et les mises à jours ultérieures de Lynx.
J'ai donc ajouté deux caractères "valides" pour la détection du 'linktype', à savoir '"' et '%'.
Après reconfiguration, cela semble fonctionner.

J'en ai profité pour apporter la modification dans le fichier 'init_lynxbot', pour, par exemple, avoir le LB_stop fonctionnant correctement.

### Correction dans init_lynxbot
<img width="956" height="1004" alt="lynxbot_init_lynxbot_FIX" src="https://github.com/user-attachments/assets/6734eead-ba2a-4a7f-8c2f-88e84784f868" />

### linktype non détecté
<img width="1717" height="1004" alt="lynxbot_wrong_linktype_detection" src="https://github.com/user-attachments/assets/aa6d665f-7e04-4c34-bed5-833bea9c93cc" />

### Correction
<img width="931" height="365" alt="lynxbot_wrong_linktype_detection_FIX" src="https://github.com/user-attachments/assets/485251cf-40f1-4764-b264-28d507a95629" />

### Fonctionnement correct
<img width="1718" height="1001" alt="lynxbot_wrong_linktype_detection_FIXED" src="https://github.com/user-attachments/assets/47cebd64-988c-4b42-b4fd-cfe25fe21f20" />
